### PR TITLE
Add a '/' after the currency id for api requests

### DIFF
--- a/coinmarketcap/core.py
+++ b/coinmarketcap/core.py
@@ -51,6 +51,8 @@ class Market(object):
 
 		params = {}
 		params.update(kwargs)
+		if currency:
+			currency = currency + '/'
 		response = self.__request('ticker/' + currency, params)
 		return response
 


### PR DESCRIPTION
Fixes a small error in the endpoint used for currency-specific ticker requests. Requests of the form ticker/bitcoin?param cause a 301 redirect from the coinmarketcap API. The correct endpoint is ticker/bitcoin/?param (with a '/') between the currency symbol and the ?param.

In the current state the redirect is handled automatically by urllib so everything still functions correctly for the user but there is an extra http request for each currency ticker request.