### PR TITLE
Allow saving cache data to a temp directory

### DIFF
--- a/coinmarketcap/core.py
+++ b/coinmarketcap/core.py
@@ -2,8 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import json
+import os
 import requests
 import requests_cache
+import tempfile
 
 class Market(object):
 
@@ -11,14 +13,16 @@ class Market(object):
 	__DEFAULT_BASE_URL = 'https://api.coinmarketcap.com/v1/'
 	__DEFAULT_TIMEOUT = 120
 
-	def __init__(self, base_url = __DEFAULT_BASE_URL, request_timeout = __DEFAULT_TIMEOUT):
+	def __init__(self, base_url = __DEFAULT_BASE_URL, request_timeout = __DEFAULT_TIMEOUT, tempdir_cache = False):
 		self.base_url = base_url
 		self.request_timeout = request_timeout
+		cache_filename = 'coinmarketcap_cache'
+		self.cache_name = os.path.join(tempfile.gettempdir(), cache_filename) if tempdir_cache else cache_filename
 
 	@property
 	def session(self):
 		if not self._session:
-			self._session = requests_cache.core.CachedSession(cache_name='coinmarketcap_cache', backend='sqlite', expire_after=120)
+			self._session = requests_cache.core.CachedSession(cache_name=self.cache_name, backend='sqlite', expire_after=120)
 			self._session.headers.update({'Content-Type': 'application/json'})
 			self._session.headers.update({'User-agent': 'coinmarketcap - python wrapper \
 		around coinmarketcap.com (github.com/mrsmn/coinmarketcap-api)'})

--- a/coinmarketcap/core.py
+++ b/coinmarketcap/core.py
@@ -12,8 +12,9 @@ class Market(object):
 	_session = None
 	__DEFAULT_BASE_URL = 'https://api.coinmarketcap.com/v1/'
 	__DEFAULT_TIMEOUT = 120
+	__TEMPDIR_CACHE = False
 
-	def __init__(self, base_url = __DEFAULT_BASE_URL, request_timeout = __DEFAULT_TIMEOUT, tempdir_cache = False):
+	def __init__(self, base_url = __DEFAULT_BASE_URL, request_timeout = __DEFAULT_TIMEOUT, tempdir_cache = __TEMPDIR_CACHE):
 		self.base_url = base_url
 		self.request_timeout = request_timeout
 		cache_filename = 'coinmarketcap_cache'

--- a/coinmarketcap/core.py
+++ b/coinmarketcap/core.py
@@ -12,7 +12,7 @@ class Market(object):
 	_session = None
 	__DEFAULT_BASE_URL = 'https://api.coinmarketcap.com/v1/'
 	__DEFAULT_TIMEOUT = 120
-	__TEMPDIR_CACHE = False
+	__TEMPDIR_CACHE = True
 
 	def __init__(self, base_url = __DEFAULT_BASE_URL, request_timeout = __DEFAULT_TIMEOUT, tempdir_cache = __TEMPDIR_CACHE):
 		self.base_url = base_url


### PR DESCRIPTION
Adds a 'tempdir_cache' boolean option to the Market class which allows
the cached market data to be saved to the system temp directory rather
than the current working directory. This avoids polluting the working
directory with a short-term file that the user likely doesn't need to
be able to directly access themselves.

By default the tempdir is not used (for backwards compatibility) and
has to be explicitly requested by passing 'tempdir_cache = True' when
instantiating a Market object.

An alternative approach would be to just allow the user to specify the filename and location they want to store the file in but given that 99% of the time I imagine people wouldn't really care, it is probably simpler to have it as a boolean option to put it in the temp directory (or make it default if backwards compatibility is not a concern).